### PR TITLE
refactor: change expose attribs to lowercase.

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,12 +14,12 @@ module.exports = function Lapin ( Rabbit ) {
 
 	// Export interfaces
 	return {
-		'Requester'  : reqRes.Requester,
-		'Responder'  : reqRes.Responder,
-		'Sender'     : sendRec.Sender,
-		'Receiver'   : sendRec.Receiver,
-		'Publisher'  : pubSub.Publisher,
-		'Subscriber' : pubSub.Subscriber
+		'requester'  : reqRes.requester,
+		'responder'  : reqRes.responder,
+		'sender'     : sendRec.sender,
+		'receiver'   : sendRec.receiver,
+		'publisher'  : pubSub.publisher,
+		'subscriber' : pubSub.subscriber
 	};
 
 };

--- a/lib/pub-sub.js
+++ b/lib/pub-sub.js
@@ -68,8 +68,8 @@ module.exports = function PubSub ( Rabbit ) {
 	}
 
 	return {
-		'Publisher'  : getPublisher,
-		'Subscriber' : getSubscriber
+		'publisher'  : getPublisher,
+		'subscriber' : getSubscriber
 	};
 
 };

--- a/lib/req-res.js
+++ b/lib/req-res.js
@@ -77,8 +77,8 @@ module.exports = function ReqRes ( Rabbit ) {
 	}
 
 	return {
-		'Requester' : getRequester,
-		'Responder' : getResponder
+		'requester' : getRequester,
+		'responder' : getResponder
 	};
 
 };

--- a/lib/send-receive.js
+++ b/lib/send-receive.js
@@ -72,8 +72,8 @@ module.exports = function SendReceive ( Rabbit ) {
 	}
 
 	return {
-		'Sender'   : getSender,
-		'Receiver' : getReceiver
+		'sender'   : getSender,
+		'receiver' : getReceiver
 	};
 
 };

--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ The following are simple usage examples:
 
 ```javascript
 // Sender
-var sender = new lapin.Sender( { 'messageType' : 'v1.logs.log' } );
+var sender = lapin.sender( { 'messageType' : 'v1.logs.log' } );
 sender.produce( message, function ( error, response ) {
 
 	// handling the response is optional
@@ -41,7 +41,7 @@ sender.produce( message, function ( error, response ) {
 } );
 
 // Receiver
-var receiver = new lapin.Receiver( { 'messageType' : 'v1.logs.log' } );
+var receiver = lapin.receiver( { 'messageType' : 'v1.logs.log' } );
 receiver.consume( function ( message, done ) {
 
   someDatabaseQuery( message, function ( err, body ) {
@@ -61,7 +61,7 @@ receiver.consume( function ( message, done ) {
 
 ```javascript
 // Publisher
-var publisher = new lapin.Publisher( { 'messageType' : 'v1.users.login' } );
+var publisher = lapin.publisher( { 'messageType' : 'v1.users.login' } );
 publisher.produce( message, function ( error, response ) {
 
     // handling the response is optional
@@ -73,7 +73,7 @@ publisher.produce( message, function ( error, response ) {
 
 
 // Subscriber
-var subscriber = new lapin.Receiver( { 'messageType' : 'v1.users.login' } );
+var subscriber = lapin.receiver( { 'messageType' : 'v1.users.login' } );
 subscriber.consume( function ( message, done ) {
 
   someDatabaseQuery( message, function ( err, body ) {
@@ -93,7 +93,7 @@ subscriber.consume( function ( message, done ) {
 
 ```javascript
 // Requester
-var requester = new lapin.Requester( { 'messageType' : 'v1.users.findAll' } );
+var requester = lapin.requester( { 'messageType' : 'v1.users.findAll' } );
 requester.produce( message, function ( error, data ) {
 
 	if ( error ) {
@@ -104,7 +104,7 @@ requester.produce( message, function ( error, data ) {
 } );
 
 // Responder
-var responder = new lapin.Responder( { 'messageType' : 'v1.users.findAll' } );
+var responder = lapin.responder( { 'messageType' : 'v1.users.findAll' } );
 responder.consume( function ( message, respond ) {
 
 	someDatabaseQuery().success( function ( result ) {

--- a/test/pub-sub-test.js
+++ b/test/pub-sub-test.js
@@ -29,7 +29,7 @@ describe( 'publisher / subscriber', function () {
 
 		before( function ( done ) {
 			try {
-				publisher = new Lapin.Publisher( options );
+				publisher = Lapin.publisher( options );
 			} catch ( exception ) {
 				console.error( exception );
 			}
@@ -62,7 +62,7 @@ describe( 'publisher / subscriber', function () {
 
 			before( function ( done ) {
 				try {
-					publisher   = new Lapin.Publisher( options );
+					publisher   = Lapin.publisher( options );
 					publishStub = sinon.stub( publisher, 'publish', function () {} );
 				} catch ( exception ) {
 					console.error( exception );
@@ -91,7 +91,7 @@ describe( 'publisher / subscriber', function () {
 
 		before( function ( done ) {
 			try {
-				subscriber = new Lapin.Subscriber( options );
+				subscriber = Lapin.subscriber( options );
 			} catch ( exception ) {
 				console.error( exception );
 			}
@@ -130,7 +130,7 @@ describe( 'publisher / subscriber', function () {
 
 			before( function ( done ) {
 				try {
-					subscriber    = new Lapin.Subscriber( options );
+					subscriber    = Lapin.subscriber( options );
 					subscribeStub = sinon.stub( subscriber, 'subscribe', function () {} );
 				} catch ( exception ) {
 					console.error( exception );

--- a/test/req-res-test.js
+++ b/test/req-res-test.js
@@ -29,7 +29,7 @@ describe( 'requester / responder', function () {
 
 		before( function ( done ) {
 			try {
-				requester = new Lapin.Requester( options );
+				requester = Lapin.requester( options );
 			} catch ( exception ) {
 				console.error( exception );
 			}
@@ -62,7 +62,7 @@ describe( 'requester / responder', function () {
 
 			before( function ( done ) {
 				try {
-					requester   = new Lapin.Requester( options );
+					requester   = Lapin.requester( options );
 					requestStub = sinon.stub( requester, 'request', function () {} );
 				} catch ( exception ) {
 					console.error( exception );
@@ -91,7 +91,7 @@ describe( 'requester / responder', function () {
 
 		before( function ( done ) {
 			try {
-				responder = new Lapin.Responder( options );
+				responder = Lapin.responder( options );
 			} catch ( exception ) {
 				console.error( exception );
 			}
@@ -130,7 +130,7 @@ describe( 'requester / responder', function () {
 
 			before( function ( done ) {
 				try {
-					responder  = new Lapin.Responder( options );
+					responder  = Lapin.responder( options );
 					handleStub = sinon.stub( responder, 'handle', function () {} );
 				} catch ( exception ) {
 					console.error( exception );

--- a/test/send-receive-test.js
+++ b/test/send-receive-test.js
@@ -29,7 +29,7 @@ describe( 'sender / receiver', function () {
 
 		before( function ( done ) {
 			try {
-				sender = new Lapin.Sender( options );
+				sender = Lapin.sender( options );
 			} catch ( exception ) {
 				console.error( exception );
 			}
@@ -62,7 +62,7 @@ describe( 'sender / receiver', function () {
 
 			before( function ( done ) {
 				try {
-					sender   = new Lapin.Sender( options );
+					sender   = Lapin.sender( options );
 					sendStub = sinon.stub( sender, 'send', function () {} );
 				} catch ( exception ) {
 					console.error( exception );
@@ -91,7 +91,7 @@ describe( 'sender / receiver', function () {
 
 		before( function ( done ) {
 			try {
-				receiver = new Lapin.Receiver( options );
+				receiver = Lapin.receiver( options );
 			} catch ( exception ) {
 				console.error( exception );
 			}
@@ -130,7 +130,7 @@ describe( 'sender / receiver', function () {
 
 			before( function ( done ) {
 				try {
-					receiver    = new Lapin.Receiver( options );
+					receiver    = Lapin.receiver( options );
 					receiveStub = sinon.stub( receiver, 'receive', function () {} );
 				} catch ( exception ) {
 					console.error( exception );


### PR DESCRIPTION
- since obj creation is handled by lapin

With the abstraction of lapin's Producer/Consumer object creation - we also change the expose attributes. Leaving the attributes to `uppercase` will conflict with our `newcap` jshint rule.

Conflicts:
	lib/req-res.js