### PR TITLE
fix: change -message- to -data-  attribute

### DIFF
--- a/lib/pub-sub/publisher.js
+++ b/lib/pub-sub/publisher.js
@@ -33,8 +33,8 @@ Publisher.prototype.produce = function ( message, callback ) {
 
 	if ( !message || message === 'undefined' ) {
 		return callback( {
-			'status'  : 'fail',
-			'message' : 'Invalid data'
+			'status' : 'fail',
+			'data'   : 'Invalid data'
 		}, null );
 	}
 

--- a/lib/req-res/requester.js
+++ b/lib/req-res/requester.js
@@ -36,8 +36,8 @@ Requester.prototype.produce = function ( message, callback ) {
 	// in the future this should be `fail`
 	if ( !message || message === 'undefined' ) {
 		return callback( {
-			'status'  : 'fail',
-			'message' : 'Invalid data'
+			'status' : 'fail',
+			'data'   : 'Invalid data'
 		}, null );
 	}
 	this.request( message, function ( response ) {

--- a/lib/send-rec/sender.js
+++ b/lib/send-rec/sender.js
@@ -34,15 +34,15 @@ Sender.prototype.produce = function ( message, callback ) {
 
 	if ( !message || message === 'undefined' ) {
 		return callback( {
-			'status'  : 'fail',
-			'message' : 'Invalid data'
+			'status' : 'fail',
+			'data'   : 'Invalid data'
 		}, null );
 	}
 
 	this.send( message, function () {
 		callback( null, {
-			'status'  : 'success',
-			'message' : 'Message sent'
+			'status' : 'success',
+			'data'   : 'Message sent'
 		} );
 
 	} );

--- a/test/it/pub-sub.js
+++ b/test/it/pub-sub.js
@@ -88,7 +88,7 @@ describe( 'Perform publish subscribe', function () {
 
 			expect( failData ).be.an( 'object' );
 			expect( failData.status ).to.exist.and.to.equal( 'fail' );
-			expect( failData.message ).to.exist.and.to.equal( 'Invalid data' );
+			expect( failData.data ).to.exist.and.to.equal( 'Invalid data' );
 
 		} );
 

--- a/test/it/req-res.js
+++ b/test/it/req-res.js
@@ -360,7 +360,7 @@ describe( 'Perform request respond', function () {
 
 			expect( failData ).be.an( 'object' );
 			expect( failData.status ).to.exist.and.to.equal( 'fail' );
-			expect( failData.message ).to.exist.and.to.equal( 'Invalid data' );
+			expect( failData.data ).to.exist.and.to.equal( 'Invalid data' );
 
 		} );
 

--- a/test/it/send-receive-msg-types.js
+++ b/test/it/send-receive-msg-types.js
@@ -51,7 +51,7 @@ describe( 'Perform Send Receive multiple messageTypes', function () {
 
 			expect( received ).be.an( 'object' );
 			expect( received.status ).to.exist.and.to.equal( 'success' );
-			expect( received.message ).to.exist.and.to.equal( 'Message sent' );
+			expect( received.data ).to.exist.and.to.equal( 'Message sent' );
 
 		} );
 	} );

--- a/test/it/send-receive-promise.js
+++ b/test/it/send-receive-promise.js
@@ -52,7 +52,7 @@ describe( 'Perform Send( PROMISE ) Receive', function () {
 
 		expect( received ).be.an( 'object' );
 		expect( received.status ).to.exist.and.to.equal( 'success' );
-		expect( received.message ).to.exist.and.to.equal( 'Message sent' );
+		expect( received.data ).to.exist.and.to.equal( 'Message sent' );
 
 	} );
 

--- a/test/it/send-receive.js
+++ b/test/it/send-receive.js
@@ -46,7 +46,7 @@ describe( 'Perform Send Receive', function () {
 
 			expect( received ).be.an( 'object' );
 			expect( received.status ).to.exist.and.to.equal( 'success' );
-			expect( received.message ).to.exist.and.to.equal( 'Message sent' );
+			expect( received.data ).to.exist.and.to.equal( 'Message sent' );
 
 		} );
 	} );
@@ -87,7 +87,7 @@ describe( 'Perform Send Receive', function () {
 
 			expect( received ).be.an( 'object' );
 			expect( received.status ).to.exist.and.to.equal( 'success' );
-			expect( received.message ).to.exist.and.to.equal( 'Message sent' );
+			expect( received.data ).to.exist.and.to.equal( 'Message sent' );
 
 		} );
 	} );
@@ -116,7 +116,7 @@ describe( 'Perform Send Receive', function () {
 
 			expect( failData ).be.an( 'object' );
 			expect( failData.status ).to.exist.and.to.equal( 'fail' );
-			expect( failData.message ).to.exist.and.to.equal( 'Invalid data' );
+			expect( failData.data ).to.exist.and.to.equal( 'Invalid data' );
 
 		} );
 


### PR DESCRIPTION
conform to JSEND
this can wait to future another future release - not something that really breaks, changes only occurs when no message is passed in lapin except for the lapin.send which I change to return 
```
{
  'status' : 'success',
  'data' : 'Message Sent'
}
```