### PR TITLE
fix: pass joi validate results to respond handlers instead of `message`

### DIFF
--- a/lib/req-res/responder.js
+++ b/lib/req-res/responder.js
@@ -61,8 +61,8 @@ Responder.prototype.consume = function ( callback ) {
 				'schema'  : that.vSchema,
 				'options' : that.vOptions
 			} )
-			.then( function () {
-				callback( message, requestStatus( statusOptions ) );
+			.then( function ( data ) {
+				callback( data, requestStatus( statusOptions ) );
 			} )
 			.catch( function ( error ) {
 				// send fail

--- a/test/it/req-res/req-res.js
+++ b/test/it/req-res/req-res.js
@@ -130,7 +130,7 @@ describe( 'Perform request respond', function () {
 		var validationData = {
 			'username'  : 'Testfoo',
 			'password'  : 'foo',
-			'birthyear' : '1990'
+			'birthyear' : 1990
 		};
 
 		before( function ( done ) {


### PR DESCRIPTION
- Fixes issues where `requestData` in handlers is a JSON string instead of an object.
- Makes Joi.default() work.